### PR TITLE
panther nerf

### DIFF
--- a/code/__DEFINES/~RUtgmc_defines/mobs.dm
+++ b/code/__DEFINES/~RUtgmc_defines/mobs.dm
@@ -6,7 +6,7 @@
 #define PANTHER_EVASION_COOLDOWN 2.5 SECONDS // how close a nearby human has to be in order to be targeted
 #define PANTHER_EVASION_PLASMADRAIN 3
 #define PANTHER_EVASION_LOW_PLASMADRAIN 1.5
-#define PANTHER_TEARING_TAIL_REAGENT_AMOUNT 10
+#define PANTHER_TEARING_TAIL_REAGENT_AMOUNT 5
 
 //slowdown defines for liquid turfs
 

--- a/code/__DEFINES/~RUtgmc_defines/xeno.dm
+++ b/code/__DEFINES/~RUtgmc_defines/xeno.dm
@@ -48,7 +48,6 @@ GLOBAL_LIST_INIT(resin_images_list, list(
 		))
 
 GLOBAL_LIST_INIT(panther_toxin_type_list, list(
-		/datum/reagent/toxin/xeno_ozelomelyn,
 		/datum/reagent/toxin/xeno_hemodile,
 		/datum/reagent/toxin/xeno_transvitox,
 		/datum/reagent/toxin/xeno_neurotoxin,

--- a/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/panther/abilities_panther.dm
+++ b/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/panther/abilities_panther.dm
@@ -499,7 +499,6 @@
 			PANTHER_NEUROTOXIN = image('modular_RUtgmc/icons/Xeno/actions.dmi', icon_state = PANTHER_NEUROTOXIN),
 			PANTHER_HEMODILE = image('modular_RUtgmc/icons/Xeno/actions.dmi', icon_state = PANTHER_HEMODILE),
 			PANTHER_TRANSVITOX = image('modular_RUtgmc/icons/Xeno/actions.dmi', icon_state = PANTHER_TRANSVITOX),
-			PANTHER_OZELOMELYN = image('modular_RUtgmc/icons/Xeno/actions.dmi', icon_state = PANTHER_OZELOMELYN),
 			PANTHER_SANGUINAL = image('modular_RUtgmc/icons/Xeno/actions.dmi', icon_state = PANTHER_SANGUINAL),
 			)
 	var/toxin_choice = show_radial_menu(owner, owner, panther_toxin_images_list, radius = 48)
@@ -518,5 +517,4 @@
 #undef PANTHER_NEUROTOXIN
 #undef PANTHER_HEMODILE
 #undef PANTHER_TRANSVITOX
-#undef PANTHER_OZELOMELYN
 #undef PANTHER_SANGUINAL


### PR DESCRIPTION
Следуя за нерфом маровской химии, нерфится и пантера
Больше не может вводить ози
Обьём вводимых реагентов понижен с 10 до 5