### PR TITLE
[SEMI-MODULAR] Ravager changes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -548,7 +548,7 @@
 		UnregisterSignal(xeno, COMSIG_XENOMORPH_ATTACK_LIVING)
 	to_chat(xeno, span_xenonotice("You will now[xeno.vampirism ? "" : " no longer"] heal from attacking"))
 
-///Adds the slashed mob to tracked damage mobs
+/*///Adds the slashed mob to tracked damage mobs
 /datum/action/xeno_action/vampirism/proc/on_slash(datum/source, mob/living/target, damage, list/damage_mod, list/armor_mod)
 	SIGNAL_HANDLER
 	if(target.stat == DEAD)
@@ -564,4 +564,4 @@
 	particle_holder = new(x, /particles/xeno_slash/vampirism)
 	particle_holder.pixel_y = 18
 	particle_holder.pixel_x = 18
-	timer_ref = QDEL_NULL_IN(src, particle_holder, heal_delay)
+	timer_ref = QDEL_NULL_IN(src, particle_holder, heal_delay)*/

--- a/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -1,0 +1,19 @@
+/datum/action/xeno_action/activable/charge
+	cooldown_timer = 14 SECONDS
+
+/datum/action/xeno_action/vampirism/proc/on_slash(datum/source, mob/living/target, damage, list/damage_mod, list/armor_mod)
+	SIGNAL_HANDLER
+	if(target.stat == DEAD)
+		return
+	if(!ishuman(target)) // no farming on animals/dead
+		return
+	if(timeleft(timer_ref) > 0)
+		return
+	var/mob/living/carbon/xenomorph/x = owner
+	x.adjustBruteLoss(-x.bruteloss * 0.2)
+	x.adjustFireLoss(-x.fireloss * 0.2)
+	update_button_icon()
+	particle_holder = new(x, /particles/xeno_slash/vampirism)
+	particle_holder.pixel_y = 18
+	particle_holder.pixel_x = 18
+	timer_ref = QDEL_NULL_IN(src, particle_holder, heal_delay)

--- a/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -1,5 +1,5 @@
 /datum/xeno_caste/ravager
-	plasma_regen_limit = 0.6
+	plasma_regen_limit = 0.7
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 55, BULLET = 60, LASER = 60, ENERGY = 50, BOMB = 10, BIO = 40, FIRE = 70, ACID = 40)

--- a/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -1,0 +1,35 @@
+/datum/xeno_caste/ravager
+	plasma_regen_limit = 0.6
+
+	// *** Defense *** //
+	soft_armor = list(MELEE = 55, BULLET = 60, LASER = 60, ENERGY = 50, BOMB = 10, BIO = 40, FIRE = 70, ACID = 40)
+
+	// *** Abilities *** //
+	actions = list(
+		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
+		/datum/action/xeno_action/activable/psydrain,
+		/datum/action/xeno_action/activable/charge,
+		/datum/action/xeno_action/activable/ravage,
+	)
+
+/datum/xeno_caste/ravager/on_caste_applied(mob/xenomorph)
+	. = ..()
+	xenomorph.AddElement(/datum/element/plasma_on_attack, 1.8)
+	xenomorph.AddElement(/datum/element/plasma_on_attacked, 0.8)
+
+/datum/xeno_caste/ravager/on_caste_removed(mob/xenomorph)
+	. = ..()
+	xenomorph.RemoveElement(/datum/element/plasma_on_attack, 1.8)
+	xenomorph.RemoveElement(/datum/element/plasma_on_attacked, 0.8)
+
+/datum/xeno_caste/ravager/primordial
+	// *** Abilities *** //
+	actions = list(
+		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
+		/datum/action/xeno_action/activable/psydrain,
+		/datum/action/xeno_action/activable/charge,
+		/datum/action/xeno_action/activable/ravage,
+		/datum/action/xeno_action/vampirism,
+	)

--- a/modular_RUtgmc/includes.dm
+++ b/modular_RUtgmc/includes.dm
@@ -186,3 +186,5 @@
 #include "code\modules\clothing\modular_armor\jaeger.dm"
 #include "code\modules\clothing\modular_armor\attachments\chest_plates.dm"
 #include "code\modules\reagents\reactions\medical.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\ravager\castedatum_ravager.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\ravager\abilities_ravager.dm"


### PR DESCRIPTION
## About The Pull Request
Концептуально каста, которая должна постоянно следить за своим ХП, намеренно давать марам довести себя до крита, чтобы потом прожать супер рейдж и получить огромный бафф к урону и скорости, выглядит очень круто и интересно, сложно и скиллозависимо. На деле же, при таких высоких рисках умереть, у равагера очень маленький выхлоп. 
Неоправданно большой урон у стоковых пушек маров, механика сандера, внушительная разница между ценой жизни т3 ксена и рядового марина делают существование high risk high reward механов ненужными. Равагер сейчас никак не влияет на общую боеспособность хайва, на ситуацию на поле боя. Хайв играет и выигрывает другими кастами. Надеюсь изменения сделают равагера ксеносом полезным и надежным.

Изменения следующие:
Endure и Rage убраны из списка абилок.
Eviscerating Charge КД понижен до 14 секунд.
Лимит регена плазмы увеличен до 560.
Броня
   Было: MELEE = 50, BULLET = 55, LASER = 50
   Стало: MELEE = 55, BULLET = 60, LASER = 60
Получает немного больше плазмы с атак и входящего урона.
Абилка Вампиризм восстанавливает значительно больше ХП.