### PR TITLE
[SEMI-MODULAR] Partly removes sunder

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -608,12 +608,12 @@
 	playsound(debuff_owner.loc, "sound/bullets/acid_impact1.ogg", 4)
 	particle_holder.particles.spawning = 1 + round(stacks / 2)
 
-	debuff_owner.apply_damage(STATUS_EFFECT_MELTING_DAMAGE, BURN, null, FIRE)
+	debuff_owner.apply_damage(STATUS_EFFECT_MELTING_DAMAGE * 2.5, BURN, null, FIRE) //RUTGMC EDIT
 
-	if(!isxeno(debuff_owner))
+/*	if(!isxeno(debuff_owner))
 		return
 	var/mob/living/carbon/xenomorph/xenomorph_owner = debuff_owner
-	xenomorph_owner.adjust_sunder(STATUS_EFFECT_MELTING_SUNDER_DAMAGE)
+	xenomorph_owner.adjust_sunder(STATUS_EFFECT_MELTING_SUNDER_DAMAGE) RUTGMC EDIT*/
 
 /atom/movable/screen/alert/status_effect/melting
 	name = "Melting"

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -885,8 +885,8 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 		if(IgniteMob())
 			feedback_flags |= (BULLET_FEEDBACK_FIRE)
 
-	if(proj.ammo.flags_ammo_behavior & AMMO_SUNDERING)
-		adjust_sunder(proj.sundering)
+//	if(proj.ammo.flags_ammo_behavior & AMMO_SUNDERING)
+//		adjust_sunder(proj.sundering) RUTGMC EDIT
 
 	if(stat != DEAD && ismob(proj.firer))
 		record_projectile_damage(proj.firer, damage)	//Tally up whoever the shooter was

--- a/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -1,0 +1,37 @@
+/mob/living/carbon/xenomorph/ex_act(severity)
+	if(status_flags & (INCORPOREAL|GODMODE))
+		return
+
+	var/ex_damage
+	var/stagger_amount = 0
+	var/slowdown_amount = 0
+	var/bomb_armor_ratio = modify_by_armor(1, BOMB) //percentage that pierces overall bomb armor
+
+	if(bomb_armor_ratio <= 0) //we have 100 effective bomb armor
+		return
+
+	if((severity == EXPLODE_DEVASTATE) && (bomb_armor_ratio > XENO_EXPLOSION_GIB_THRESHOLD))
+		return gib() //Gibs unprotected benos
+
+	switch(severity)
+		if(EXPLODE_DEVASTATE)
+			ex_damage = rand(190, 210)
+			stagger_amount = 4 * bomb_armor_ratio - 1
+			slowdown_amount = 5 * bomb_armor_ratio
+		if(EXPLODE_HEAVY)
+			ex_damage = rand(140, 160)
+			stagger_amount = 3 * bomb_armor_ratio - 1
+			slowdown_amount = 4 * bomb_armor_ratio
+		if(EXPLODE_LIGHT)
+			ex_damage = rand(90, 110)
+			stagger_amount = 2 * bomb_armor_ratio - 1
+			slowdown_amount = 3 * bomb_armor_ratio
+		if(EXPLODE_WEAK)
+			ex_damage = rand(40, 60)
+			slowdown_amount = 2 * bomb_armor_ratio
+
+	if(stagger_amount > 0)
+		adjust_stagger(stagger_amount)
+	add_slowdown(slowdown_amount)
+
+	apply_damages(ex_damage * 0.5, ex_damage * 0.5, blocked = BOMB, updating_health = TRUE)

--- a/modular_RUtgmc/code/modules/projectiles/ammo_datums.dm
+++ b/modular_RUtgmc/code/modules/projectiles/ammo_datums.dm
@@ -169,3 +169,9 @@
 	if(T.density)
 		return
 	new /obj/effect/xenomorph/spray/weak(T, puddle_duration, puddle_acid_damage)
+
+/datum/ammo/bullet/shotgun/flechette
+	penetration = 30
+
+/datum/ammo/bullet/shotgun/tx15_flechette
+	penetration = 30

--- a/modular_RUtgmc/includes.dm
+++ b/modular_RUtgmc/includes.dm
@@ -191,3 +191,4 @@
 #include "code\modules\reagents\reactions\medical.dm"
 #include "code\datums\status_effects\debuffs.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\king\abilities_king.dm"
+#include "code\modules\mob\living\carbon\xenomorph\damage_procs.dm"


### PR DESCRIPTION
## About The Pull Request
Механ слишком сильно облегчает марам убийство ксеноморфов, совет геймдизайнеров в лице меня, меня и меня вынес приговор о удалении. Пули и взрывы больше не снимают сандер.

Сами по себе пушки не стали слишком слабыми(тот же ар-11 теперь тратит полный магазин для убийства Кинга), но некоторые патроны слишком сильно опирались на сандеринг, дабы не сделать их совсем уж бесполезными, баффнул им другие статы:

Флешеттам увеличено АП(бронепробитие) до 30.
Дебафф Melting у лазерок теперь дамажит 12,5 вместо 5.

## Why It's Good For The Game
Много лет назад этот механ вводили дабы по словам кодера увеличить импакт у саппорт ролей. Далее, путем многократных изменений, оффы пришли к тому, что на данный момент практически каждая пушка в игре имеет сандеринг(А где-то у прожектайлов и АП, и сандеринг, охуенно сделано).
Опуская то, что касты танков у хайва не существует как явления, механ сандеринга полностью нивелирует смысл ксеноморфам жить больше десяти минут. Ксеносу после первой же стычки с марами могут снять 20-50% сандеринга. Далее у него выбор - либо идет хилить сандер, выпадая из раунда на некоторое время, либо выходит второй раз и ловит ваншот от дробовика с флешетами(как тот же равагер, например).
Удалив сандеринг, оживим остальные виды патронов, такие как: патроны с высоким бронепробитием, со станом, со стаггером и с поджогом. Пусть учатся использовать разные виды патрон.