### PR TITLE
[FIX][MODULAR] Fix-chemrettes

### DIFF
--- a/modular_RUtgmc/code/game/objects/items/storage/fancy.dm
+++ b/modular_RUtgmc/code/game/objects/items/storage/fancy.dm
@@ -1,0 +1,3 @@
+/obj/item/storage/fancy/chemrettes
+	max_storage_space = 18
+	storage_slots = 18

--- a/modular_RUtgmc/includes.dm
+++ b/modular_RUtgmc/includes.dm
@@ -155,6 +155,7 @@
 #include "code\game\objects\items\storage\boxes.dm"
 #include "code\game\objects\items\storage\holsters.dm"
 #include "code\game\objects\items\storage\dispenser.dm"
+#include "code\game\objects\items\storage\fancy.dm"
 #include "code\game\objects\items\weapons\blades.dm"
 #include "code\game\objects\items\weapons\twohanded.dm"
 #include "code\game\objects\items\tools\soldering_tool.dm"


### PR DESCRIPTION

## Фикс химреток по запросу https://github.com/Cosmic-Overlord/RU-TerraGov-Marine-Corps/issues/168#issue-2010265209

До этого можно было засунуть в пачку сигарет больше 18 штук, что ломало спрайт. Теперь нельзя больше 18, ибо апдейт икон идет от количества сигареток и выбирает такой по номеру спрайт. А у нас ровно 18 спрайтов.