### PR TITLE
[MODULAR] Laser carbine tweak

### DIFF
--- a/modular_RUtgmc/code/modules/projectiles/guns/energy.dm
+++ b/modular_RUtgmc/code/modules/projectiles/guns/energy.dm
@@ -75,24 +75,6 @@
 	radial_icon = 'modular_RUtgmc/icons/mob/radial.dmi'
 
 /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_carbine
-	attachable_allowed = list(
-		/obj/item/attachable/bayonet,
-		/obj/item/attachable/bayonetknife,
-		/obj/item/attachable/bayonetknife/som,
-		/obj/item/attachable/reddot,
-		/obj/item/attachable/lasersight,
-		/obj/item/attachable/flashlight,
-		/obj/item/attachable/magnetic_harness,
-		/obj/item/weapon/gun/grenade_launcher/underslung,
-		/obj/item/weapon/gun/flamer/mini_flamer,
-		/obj/item/attachable/motiondetector,
-		/obj/item/attachable/buildasentry,
-		/obj/item/weapon/gun/rifle/pepperball/pepperball_mini,
-		/obj/item/attachable/shoulder_mount,
-		/obj/item/attachable/verticalgrip,
-		/obj/item/attachable/angledgrip,
-		/obj/item/attachable/flashlight/under,
-	)
 	autoburst_delay = 1.3 SECONDS
 	akimbo_additional_delay = 2
 

--- a/modular_RUtgmc/code/modules/projectiles/guns/energy.dm
+++ b/modular_RUtgmc/code/modules/projectiles/guns/energy.dm
@@ -75,7 +75,26 @@
 	radial_icon = 'modular_RUtgmc/icons/mob/radial.dmi'
 
 /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_carbine
-	burst_delay = 0.6 SECONDS
+	attachable_allowed = list(
+		/obj/item/attachable/bayonet,
+		/obj/item/attachable/bayonetknife,
+		/obj/item/attachable/bayonetknife/som,
+		/obj/item/attachable/reddot,
+		/obj/item/attachable/lasersight,
+		/obj/item/attachable/flashlight,
+		/obj/item/attachable/magnetic_harness,
+		/obj/item/weapon/gun/grenade_launcher/underslung,
+		/obj/item/weapon/gun/flamer/mini_flamer,
+		/obj/item/attachable/motiondetector,
+		/obj/item/attachable/buildasentry,
+		/obj/item/weapon/gun/rifle/pepperball/pepperball_mini,
+		/obj/item/attachable/shoulder_mount,
+		/obj/item/attachable/verticalgrip,
+		/obj/item/attachable/angledgrip,
+		/obj/item/attachable/flashlight/under,
+	)
+	autoburst_delay = 1.3 SECONDS
+	akimbo_additional_delay = 2
 
 /obj/item/weapon/gun/energy/lasgun/lasrifle/xray
 	fire_delay = 0.4 SECONDS


### PR DESCRIPTION
## About The Pull Request
burst_delay снова 0.1 секунды.
autoburst_delay увеличен до 1,3 секунд
akimbo_additional_delay теперь равен  2

## Why It's Good For The Game
Прошлый мой нерф несправедливо убил карабин как оружие. В этом же я понерфил именно то, из-за чего он и становился слишком сильным оружием. Пушка снова может использоваться в бою, как в одноручном, так и в двуручном хвате.