### PR TITLE
Thermobaric seasonal fix

### DIFF
--- a/modular_RUtgmc/code/controllers/subsystem/persistence.dm
+++ b/modular_RUtgmc/code/controllers/subsystem/persistence.dm
@@ -1,0 +1,7 @@
+/datum/season_datum/weapons/guns/heavy_ff
+	item_list = list(
+		/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
+		/obj/item/storage/holster/backholster/rlquad/full = 2,
+		/obj/item/ammo_magazine/rocket/m57a4 = 2,
+		/obj/structure/largecrate/supply/explosives/disposable = 1,
+	)

--- a/modular_RUtgmc/code/modules/projectiles/guns/specialist.dm
+++ b/modular_RUtgmc/code/modules/projectiles/guns/specialist.dm
@@ -1,3 +1,15 @@
+/obj/item/weapon/gun/launcher/rocket/recoillessrifle
+	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER|GUN_SMOKE_PARTICLES
+
+/obj/item/weapon/gun/launcher/rocket/recoillessrifle
+	attachable_allowed = list(
+		/obj/item/attachable/magnetic_harness,
+		/obj/item/attachable/buildasentry,
+		/obj/item/attachable/shoulder_mount,
+		/obj/item/attachable/scope/mini
+	)
+
+
 /obj/item/weapon/gun/launcher/rocket/sadar
 	icon = 'modular_RUtgmc/icons/Marine/gun64.dmi'
 	icon_state = "sadar"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Заменяет термобар в сезонном тяжелом вооружении на сумку с термобаром

## Why It's Good For The Game

## Changelog

Из тяжёлых сезонок удалено 2 термобара, добавлено 2 полных сумки с термобарами, а количество ракет на термобар уменьшено с 8 до 2 (в сумках по 3)

:cl:
fix: вместо термобаров в сезонках сумки
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
