### PR TITLE
Changes acid well sticky grenades handling, acid well smoke now extinguishes and slight phosphorus trailblazer nerf.

### DIFF
--- a/modular_RUtgmc/code/game/objects/effects/effect_system/smoke.dm
+++ b/modular_RUtgmc/code/game/objects/effects/effect_system/smoke.dm
@@ -1,0 +1,5 @@
+/datum/effect_system/smoke_spread/xeno/acid/extuingishing
+	smoke_type = /obj/effect/particle_effect/smoke/xeno/burn/extinguishing
+
+/obj/effect/particle_effect/smoke/xeno/burn/extinguishing
+	smoke_traits = SMOKE_XENO|SMOKE_XENO_ACID|SMOKE_GASP|SMOKE_COUGH|SMOKE_HUGGER_PACIFY|SMOKE_EXTINGUISH

--- a/modular_RUtgmc/code/game/objects/items/explosives/marines.dm
+++ b/modular_RUtgmc/code/game/objects/items/explosives/marines.dm
@@ -27,8 +27,8 @@
 	icon_state = "grenade_sticky_phosphorus"
 	item_state = "grenade_sticky_phosphorus"
 	icon_state_mini = "grenade_trailblazer_phosphorus"
-	fire_level = 50
-	burn_level = 50
+	fire_level = 45
+	burn_level = 45
 	fire_color = "blue"
 
 /obj/item/explosive/grenade/sticky/trailblazer/phosphorus/activate(mob/user)

--- a/modular_RUtgmc/includes.dm
+++ b/modular_RUtgmc/includes.dm
@@ -48,6 +48,7 @@
 #include "code\game\objects\effects\aliens.dm"
 #include "code\game\objects\effects\overlays.dm"
 #include "code\game\objects\effects\weeds.dm"
+#include "code\game\objects\effects\effect_system\smoke.dm"
 #include "code\game\objects\effects\landmarks\landmarks.dm"
 #include "code\game\objects\effects\landmarks\marine_spawns.dm"
 #include "code\game\objects\items\misc.dm"


### PR DESCRIPTION
Колодцы теперь сразу удаляют стики гранаты, а не просто самоуничтожаются вместе с гранатой.
Дым от колодца теперь тушит, я не уверен насчёт этой идеи, но не думаю что она выльется в серьёзную проблему.
Уровень огня и уровень ожогов фосфорным трейлблезерам понижен с 50 до 45. Чтобы было ближе к x-топливу и т.п.