### PR TITLE
[TM-ONLY] line of sight fix

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -19,8 +19,7 @@
 	var/material_type
 
 /obj/structure/mineral_door/Initialize(mapload)
-	if((locate(/mob/living) in loc) && !open)	//If we build a door below ourselves, it starts open.
-		toggle_state()
+	toggle_state()
 	/*
 	We are calling parent later because if we toggle state, the opacity changes only to change to
 	non opaque after the parent procs do their thing, this is an issue because this changes the


### PR DESCRIPTION
## About The Pull Request
Двери спавнятся непрозрачными, турф под ними это видит и тоже становится непрозрачным со всех сторон. В итоге line of sight нахуй ломается и ксеносы не могут использовать свои абилки на все, что находится в дверях, или если они сами стоят в них. Спасибо ивамихо за рефактор
На оффах этого бага нет, но есть у нас. Почему - хуй знает. Как обновимся до оффов этот пр надо будет закрыть

## Why It's Good For The Game
Багфикс
