### PR TITLE
Suppressor Refactor

### DIFF
--- a/modular_RUtgmc/code/modules/projectiles/gun_attachables.dm
+++ b/modular_RUtgmc/code/modules/projectiles/gun_attachables.dm
@@ -1,3 +1,19 @@
+/obj/item/attachable/suppressor
+	name = "suppressor"
+	desc = "A small tube with exhaust ports to expel noise and gas.\nDoes not completely silence a weapon, but does make it much quieter and a little more accurate and stable."
+	icon_state = "suppressor"
+	slot = ATTACHMENT_SLOT_MUZZLE
+	silence_mod = TRUE
+	pixel_shift_y = 16
+	attach_shell_speed_mod = 0.5
+	accuracy_mod = 0
+	recoil_mod = 0
+	scatter_mod = -2
+	size_mod = 1
+	recoil_unwielded_mod = 0
+	scatter_unwielded_mod = 0
+	damage_falloff_mod = 0
+
 /obj/item/attachable/stock/sgstock
 	greyscale_config = null
 	colorable_allowed = NONE


### PR DESCRIPTION
attach_shell_speed_mod = -1 --> 0.5
accuracy_mod = 0.1 --> 0
recoil_mod = -2 --> 0
scatter_mod = -2
recoil_unwielded_mod = -3 --> 0
scatter_unwielded_mod = -2 --> 0
damage_falloff_mod = 0.1 --> 0

Делает из глушителя что-то более полезное, убирая уменьшение скорости пули и урона. Но убирает все огромные баффы к отдаче и отныне прибавляет +1 к размеру оружия, что весьма логично.