### PR TITLE
No more infinite M-22 fuel

### DIFF
--- a/modular_RUtgmc/code/game/objects/machinery/vending/marine_vending.dm
+++ b/modular_RUtgmc/code/game/objects/machinery/vending/marine_vending.dm
@@ -273,7 +273,7 @@
 			/obj/item/storage/backpack/marine/standard/molle = -1,
 			/obj/item/storage/backpack/marine/satchel/molle = -1,
 			/obj/item/storage/backpack/marine/standard/scav = -1,
-			/obj/item/tool/weldpack/marinestandard = -1,
+			/obj/item/tool/weldpack/marinestandard = 5,
 			/obj/item/storage/backpack/marine/satchel/tech = 2,
 			/obj/item/storage/backpack/marine/radiopack = 5,
 		),


### PR DESCRIPTION
Бесконечные переносные контейнеры топлива по 500ю (очень часто используется огнеметчиками) теперь доступны в количестве только 5 штук