### PR TITLE
[MODULAR] sniper cloak accessibility and healthanalyzer gloves to MarinMed

### DIFF
--- a/modular_RUtgmc/code/game/objects/machinery/vending/marine_vending.dm
+++ b/modular_RUtgmc/code/game/objects/machinery/vending/marine_vending.dm
@@ -377,6 +377,7 @@
 			/obj/item/defibrillator = 8,
 			/obj/item/healthanalyzer = 16,
 			/obj/item/bodybag/cryobag = 24,
+			/obj/item/healthanalyzer/gloves = 5
 		),
 	)
 
@@ -569,6 +570,7 @@
 			/obj/item/ammo_magazine/revolver/t500 = -1,
 			/obj/item/ammo_magazine/packet/t500 = -1,
 			/obj/item/ammo_magazine/packet/t500/qk = 2,
+			/obj/item/storage/backpack/marine/satchel/scout_cloak/sniper = 2
 		),
 		"Heavy Weapons" = list(
 			/obj/structure/closet/crate/mortar_ammo/mortar_kit = 1,

--- a/modular_RUtgmc/code/modules/reqs/supplypacks.dm
+++ b/modular_RUtgmc/code/modules/reqs/supplypacks.dm
@@ -211,6 +211,11 @@ ARMOR
 	cost = 600
 	available_against_xeno_only = TRUE
 
+/datum/supply_packs/armor/sniper_cloak
+	name = "Sniper Cloak"
+	contains = list(/obj/item/storage/backpack/marine/satchel/scout_cloak/sniper)
+	cost = 250
+
 /*******************************************************************************
 CLOTHING
 *******************************************************************************/


### PR DESCRIPTION
Делает снайпер плащ доступный в вендоре оружия в разделе Specialize в количестве 2 штук.
Делает снайпер плащ дешевле в карго 500 (было) 250(стало)
Возвращает перчатки сканирования в маринМед в количестве 5 штук