### PR TITLE
[Modular] Fix Cargo Mortar tangle Shell

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -930,6 +930,7 @@ EXPLOSIVES
 	contains = list(/obj/item/storage/box/mlrs_rockets_gas)
 	cost = 60
 
+/* RU TGMC EDIT BEGIN
 /datum/supply_packs/explosives/howitzer
 	name = "MG-100Y howitzer"
 	contains = list(/obj/item/mortar_kit/howitzer)
@@ -956,6 +957,7 @@ EXPLOSIVES
 	cost = 60
 	available_against_xeno_only = TRUE
 
+	RU TGMC EDIT END	*/
 /datum/supply_packs/explosives/ai_target_module
 	name = "AI artillery targeting module"
 	contains = list(/obj/item/ai_target_beacon)

--- a/modular_RUtgmc/code/modules/reqs/supplypacks.dm
+++ b/modular_RUtgmc/code/modules/reqs/supplypacks.dm
@@ -166,6 +166,32 @@ EXPLOSIVES
 	contains = list(/obj/item/storage/box/visual/grenade/trailblazer/phosphorus)
 	cost = 600
 
+/datum/supply_packs/explosives/howitzer
+	name = "TA-100Y howitzer"
+	contains = list(/obj/item/mortar_kit/howitzer)
+	cost = 600
+
+/datum/supply_packs/explosives/howitzer_ammo_he
+	name = "TA-100Y howitzer HE shell"
+	contains = list(/obj/item/mortal_shell/howitzer/he)
+	cost = 40
+
+/datum/supply_packs/explosives/howitzer_ammo_incend
+	name = "TA-100Y howitzer incendiary shell"
+	contains = list(/obj/item/mortal_shell/howitzer/incendiary)
+	cost = 40
+
+/datum/supply_packs/explosives/howitzer_ammo_wp
+	name = "TA-100Y howitzer white phosporous smoke shell"
+	contains = list(/obj/item/mortal_shell/howitzer/white_phos)
+	cost = 60
+
+/datum/supply_packs/explosives/howitzer_ammo_plasmaloss
+	name = "TA-100Y howitzer tanglefoot shell"
+	contains = list(/obj/item/mortal_shell/howitzer/plasmaloss)
+	cost = 60
+	available_against_xeno_only = TRUE
+
 /*******************************************************************************
 ARMOR
 *******************************************************************************/


### PR DESCRIPTION
## About The Pull Request

Фикс бага, что в коде карго у оффов два одинаковых датума, только один для мортиры, а другой для ховизера из-за чего один перезаписывал другой и мортирных снарядов не было в карго.

Также в описаний снарядов на ховизер были заменены приписки MG-100 на TA-100Y как он сейчас и называется в игре, а то игры в угадайку это неправильно.

## Тестирование
Работает