### PR TITLE
Restricts psylance before shutters.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -533,6 +533,10 @@
 	var/mob/living/carbon/xenomorph/xeno_owner = owner
 	if(!xeno_owner.check_state())
 		return FALSE
+	if(SSmonitor.gamestate == SHUTTERS_CLOSED && is_ground_level(owner.z) && particle_type == /particles/warlock_charge/psy_blast/psy_lance) // RUTGMC ADDITION START, NO PSYLANCE BEFORE OPEN SHUTTERS
+		if(!silent)
+			owner.balloon_alert(owner, "too early")
+		return FALSE // RUTGMC ADDITION END, NO PSYLANCE BEFORE OPEN SHUTTERS
 	var/datum/ammo/energy/xeno/selected_ammo = xeno_owner.ammo
 	if(selected_ammo.ability_cost > xeno_owner.plasma_stored)
 		if(!silent)


### PR DESCRIPTION
Я слишком тупой чтобы сделать нормальный флаг непробиваемости для створок, поэтому спиздил код с лазера кинга.