### PR TITLE
Stun mitigation component runtime fix, probably.

### DIFF
--- a/code/datums/components/stun_mitigation.dm
+++ b/code/datums/components/stun_mitigation.dm
@@ -86,7 +86,7 @@
 
 ///Actually activates the mitigation effect
 /datum/component/stun_mitigation/proc/activate_with_user()
-	RegisterSignals(affected, list(COMSIG_LIVING_PROJECTILE_STUN, COMSIG_LIVING_JETPACK_STUN), PROC_REF(on_attack_stun_mitigation))
+	RegisterSignals(affected, list(COMSIG_LIVING_PROJECTILE_STUN, COMSIG_LIVING_JETPACK_STUN), PROC_REF(on_attack_stun_mitigation), override = TRUE)
 
 ///Actually deactivates the mitigation effect
 /datum/component/stun_mitigation/proc/deactivate_with_user()


### PR DESCRIPTION
При взятии любого предмета с вышеназванным компонентом, по-типу есворда сома, топора сома, щита и б18, в руку возникает рантайм, почему, кто, зачем не понятно, но он вроде бы ни на что не влияет?
![image](https://github.com/Cosmic-Overlord/RU-TerraGov-Marine-Corps/assets/93882977/a68d2de2-2be1-4748-ac7a-43df73bfe8b5)
