### PR TITLE
Supply beacon runtime fix.

### DIFF
--- a/code/game/objects/machinery/squad_supply/supply_beacon.dm
+++ b/code/game/objects/machinery/squad_supply/supply_beacon.dm
@@ -120,7 +120,8 @@
 /obj/item/beacon/supply_beacon/onTransitZ(old_z,new_z)
 	. = ..()
 	//Assumes doMove sets loc before onTransitZ
-	beacon_datum.drop_location = loc
+	if(beacon_datum) // RUTGMC ADDITION, supply beacon runtime fix
+		beacon_datum.drop_location = loc
 
 /obj/item/beacon/supply_beacon/activate(mob/living/carbon/human/H)
 	var/area/A = get_area(H)


### PR DESCRIPTION
Если маяк не установлен и он меняет з-уровень, то он пытается поменять невыставленный параметр.
Фиксит вот это:
![image](https://github.com/Cosmic-Overlord/RU-TerraGov-Marine-Corps/assets/93882977/520e0b0c-88bc-4430-add1-1fa4c5ba84d9)
