### PR TITLE
SL locator beheading runtime fix.

### DIFF
--- a/code/game/objects/items/radio/headset.dm
+++ b/code/game/objects/items/radio/headset.dm
@@ -212,6 +212,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	user.ex_act(EXPLODE_LIGHT)
 	qdel(src)
 
+/* RUTGMC DELETION, SL_locator beheading runtime fix
 /obj/item/radio/headset/mainship/dropped(mob/living/carbon/human/user)
 	if(istype(user) && headset_hud_on)
 		disable_squadhud()
@@ -225,6 +226,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 			camera.network -= lowertext(user.assigned_squad.name)
 	UnregisterSignal(user, list(COMSIG_MOB_DEATH, COMSIG_HUMAN_SET_UNDEFIBBABLE, COMSIG_MOB_REVIVE))
 	return ..()
+*/
 
 
 /obj/item/radio/headset/mainship/Destroy()

--- a/modular_RUtgmc/code/game/objects/items/radio/headset.dm
+++ b/modular_RUtgmc/code/game/objects/items/radio/headset.dm
@@ -1,3 +1,17 @@
+/obj/item/radio/headset/mainship/dropped(mob/living/carbon/human/user)
+	if(istype(user) && headset_hud_on)
+		disable_squadhud()
+		squadhud.remove_hud_from(user)
+		user.hud_used?.SL_locator.alpha = 0
+		wearer = null
+		squadhud = null
+	if(camera)
+		camera.c_tag = "Unknown"
+		if(user.assigned_squad)
+			camera.network -= lowertext(user.assigned_squad.name)
+	UnregisterSignal(user, list(COMSIG_MOB_DEATH, COMSIG_HUMAN_SET_UNDEFIBBABLE, COMSIG_MOB_REVIVE))
+	return ..()
+
 /obj/item/radio/headset/mainship/proc/update_minimap_icon()
 	SIGNAL_HANDLER
 	SSminimaps.remove_marker(wearer)


### PR DESCRIPTION
При обезглавливании человека с этим наушником, вылезал рантайм:
![image](https://github.com/Cosmic-Overlord/RU-TerraGov-Marine-Corps/assets/93882977/0359623d-b98d-427a-a720-e1b0bdb146d8)
(На то что он в модульных файлах не смотрите, это я уже фотографировал после переноса для фикса.)