### PR TITLE
Preround resinbuilding runtime fix

### DIFF
--- a/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -17,7 +17,7 @@
 /// Extra handling for adding the action for draggin functionality (for instant building)
 /datum/action/ability/activable/xeno/secrete_resin/give_action(mob/living/L)
 	. = ..()
-	if(!(CHECK_BITFIELD(SSticker?.mode.flags_round_type, MODE_ALLOW_XENO_QUICKBUILD) || !SSresinshaping.active))
+	if(!(CHECK_BITFIELD(SSticker?.mode?.flags_round_type, MODE_ALLOW_XENO_QUICKBUILD) || !SSresinshaping.active))
 		return
 
 	var/mutable_appearance/build_maptext = mutable_appearance(icon = null,icon_state = null, layer = ACTION_LAYER_MAPTEXT)


### PR DESCRIPTION
Уберёт вот это:
![image](https://github.com/Cosmic-Overlord/RU-TerraGov-Marine-Corps/assets/93882977/5a04c960-0ee6-46a9-8b66-3fdada3ed569)