### PR TITLE
Fixes orbit breakage because of shitspawn.

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -125,8 +125,9 @@
 				marines += list(serialized)
 				continue
 
-			serialized["icon"] = job.minimap_icon
-			serialized["job"] = job.title
+			if(job) // RUTGMC ADDITION, ORBIT BREAKAGE FIX
+				serialized["icon"] = job.minimap_icon
+				serialized["job"] = job.title
 
 			if(issommarinejob(human.job))
 				som += list(serialized)


### PR DESCRIPTION
Теперь орбит не будет в попытках присвоить кукле без работы иконку работы, ломаться к хуям.
![image](https://github.com/Cosmic-Overlord/RU-TerraGov-Marine-Corps/assets/93882977/4ea18f0d-0993-4b5d-9342-7155b682a563)
