### PR TITLE
Allows to use king's laser and warlock's penetrating psylance if the tad or pod lands on ground.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -331,7 +331,7 @@
 	. = ..()
 	if(!.)
 		return
-	if(SSmonitor.gamestate == SHUTTERS_CLOSED && is_ground_level(owner.z))
+	if(is_ground_level(owner.z) && CHECK_BITFIELD(SSticker.mode?.flags_round_type, MODE_ALLOW_XENO_QUICKBUILD) && SSresinshaping.active) // RUTGMC EDIT, tad lasering
 		if(!silent)
 			owner.balloon_alert("too early")
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -533,7 +533,7 @@
 	var/mob/living/carbon/xenomorph/xeno_owner = owner
 	if(!xeno_owner.check_state())
 		return FALSE
-	if(SSmonitor.gamestate == SHUTTERS_CLOSED && is_ground_level(owner.z) && particle_type == /particles/warlock_charge/psy_blast/psy_lance) // RUTGMC ADDITION START, NO PSYLANCE BEFORE OPEN SHUTTERS
+	if(is_ground_level(owner.z) && CHECK_BITFIELD(SSticker.mode?.flags_round_type, MODE_ALLOW_XENO_QUICKBUILD) && SSresinshaping.active && particle_type == /particles/warlock_charge/psy_blast/psy_lance) // RUTGMC ADDITION START, NO PSYLANCE BEFORE OPEN SHUTTERS
 		if(!silent)
 			owner.balloon_alert(owner, "too early")
 		return FALSE // RUTGMC ADDITION END, NO PSYLANCE BEFORE OPEN SHUTTERS


### PR DESCRIPTION
Переделал проверку, чтобы она проверяла активно ли быстрая постройка и от этого уже отталкивалась, так как быстрая постройка подходит по условиям.