### PR TITLE
KeyUp verb `null.up()` runtime fix attempt.

### DIFF
--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -93,7 +93,7 @@
 	// can hold different keys and releasing any should be handled by the key binding specifically
 	for (var/kb_name in prefs.key_bindings[_key])
 		var/datum/keybinding/kb = GLOB.keybindings_by_name[kb_name]
-		if(kb.up(src))
+		if(kb && kb.up(src)) // RUTGMC ADDITION, sanity check to prevent runtimes?
 			break
 
 /**


### PR DESCRIPTION
Я не совсем разобрался как оно работает, но так как оно срёт нуллом, то простая проверка на наличие `kb` перед `kb.up(src)` должна это исправить?
![image](https://github.com/Cosmic-Overlord/RU-TerraGov-Marine-Corps/assets/93882977/a0893d28-fe73-44cb-8ceb-78c9ba912704)
