### PR TITLE
Xeno structures now qdeletes if weed node they are on isn't damaged.

### DIFF
--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -47,10 +47,12 @@
 /obj/structure/xeno/fire_act()
 	take_damage(10, BURN, FIRE)
 
+/* RUTGMC DELETION, moved to modular
 /// Destroy the xeno structure when the weed it was on is destroyed
 /obj/structure/xeno/proc/weed_removed()
 	SIGNAL_HANDLER
 	obj_destruction(damage_flag = MELEE)
+*/
 
 /obj/structure/xeno/attack_alien(mob/living/carbon/xenomorph/X, damage_amount, damage_type, damage_flag, effects, armor_penetration, isrightclick)
 	if(!(HAS_TRAIT(X, TRAIT_VALHALLA_XENO) && X.a_intent == INTENT_HARM && (tgui_alert(X, "Are you sure you want to tear down [src]?", "Tear down [src]?", list("Yes","No"))) == "Yes"))

--- a/modular_RUtgmc/code/game/objects/effects/weeds.dm
+++ b/modular_RUtgmc/code/game/objects/effects/weeds.dm
@@ -1,6 +1,12 @@
 /obj/alien/weeds
 	icon = 'modular_RUtgmc/icons/Xeno/weeds.dmi'
 
+/obj/alien/weeds/check_for_parent_node()
+	if(parent_node)
+		return
+	obj_integrity = 0 // used for xeno structures to destroy with effects
+	qdel(src)
+
 /obj/alien/weeds/weedwall
 	icon = 'modular_RUtgmc/icons/obj/smooth_objects/weedwall.dmi'
 

--- a/modular_RUtgmc/code/game/objects/effects/weeds.dm
+++ b/modular_RUtgmc/code/game/objects/effects/weeds.dm
@@ -4,7 +4,7 @@
 /obj/alien/weeds/check_for_parent_node()
 	if(parent_node)
 		return
-	obj_integrity = 0 // used for xeno structures to destroy with effects
+	obj_integrity = 0 // used for xeno structures, such as acid wells and traps, to destroy with effects
 	qdel(src)
 
 /obj/alien/weeds/weedwall

--- a/modular_RUtgmc/code/modules/xenomorph/xeno_structures.dm
+++ b/modular_RUtgmc/code/modules/xenomorph/xeno_structures.dm
@@ -1,3 +1,11 @@
+/obj/structure/xeno/proc/weed_removed()
+	SIGNAL_HANDLER
+	var/obj/alien/weeds/found_weed = locate(/obj/alien/weeds) in loc
+	if(found_weed.obj_integrity <= 0)
+		obj_destruction(damage_flag = MELEE)
+	else
+		obj_destruction()
+
 /obj/structure/xeno/silo
 	plane = FLOOR_PLANE
 	icon = 'modular_RUtgmc/icons/Xeno/resin_silo.dmi'


### PR DESCRIPTION
В основном сделано для того, чтобы при удалении травы, ловушка на траве также удалялась, а не триггерилась.
Это предотвратит кемп Кантерберри ловушками, ну и также тад будет нормально ломать ловушки.