### PR TITLE
Сhimera is now visible at orbit.

### DIFF
--- a/modular_RUtgmc/code/_globalvars/lists/flavor_misc.dm
+++ b/modular_RUtgmc/code/_globalvars/lists/flavor_misc.dm
@@ -43,6 +43,7 @@ GLOBAL_LIST_INIT(playable_icons, list(
 	"xenominion",
 	"xenoqueen",
 	"xenoshrike",
+	"chimera",
 ))
 
 GLOBAL_LIST_INIT(minimap_icons, init_minimap_icons())


### PR DESCRIPTION
Химера не была указана в списке для иконок.
![image](https://github.com/Cosmic-Overlord/RU-TerraGov-Marine-Corps/assets/93882977/94a54fd6-e105-4787-8db5-6199cc8732cb)
