### PR TITLE
Puppeteer QOL

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -920,7 +920,9 @@
 #define COMSIG_XENOABILITY_DREADFULPRESENCE "xenoability_dreadfulpresence"
 #define COMSIG_XENOABILITY_PINCUSHION "xenoability_pincushion"
 #define COMSIG_XENOABILITY_FLAY "xenoability_flay"
-#define COMSIG_XENOABILITY_SENDORDERS "xenoability_sendorders"
+#define COMSIG_XENOABILITY_SENDORDERS_RADIAL "xenoability_sendorders_radial"
+#define COMSIG_XENOABILITY_ATTACKORDER "xenoability_attackorder"
+#define COMSIG_XENOABILITY_RECALLORDER "xenoability_recallorder"
 #define COMSIG_XENOABILITY_BESTOWBLESSINGS "xenoability_giveblessings"
 
 #define COMSIG_XENOABILITY_BANELING_EXPLODE "xenoability_baneling_explode"

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -1106,11 +1106,23 @@ RU TGMC EDIT END*/
 	description = "Burrow freshly created tendrils to tangle organics in a 3x3 patch."
 	keybind_signal = COMSIG_XENOABILITY_TENDRILS
 
-/datum/keybinding/xeno/send_orders_puppet
-	name = "Give Orders to Puppets"
-	full_name = "Puppeteer: Give Orders to Puppets"
+/datum/keybinding/xeno/send_orders_puppet_radial
+	name = "Give Orders to Puppets: Radial"
+	full_name = "Puppeteer: Give Orders to Puppets (Radial)"
 	description = "Give orders to your puppets, altering their behaviour."
-	keybind_signal = COMSIG_XENOABILITY_SENDORDERS
+	keybind_signal = COMSIG_XENOABILITY_SENDORDERS_RADIAL
+
+/datum/keybinding/xeno/send_attack_order_puppet
+	name = "Give attack order"
+	full_name = "Puppeteer: Give Attack Order"
+	description = "Give your puppets order to attack"
+	keybind_signal = COMSIG_XENOABILITY_ATTACKORDER
+
+/datum/keybinding/xeno/send_recall_orders_puppet
+	name = "Give recall order"
+	full_name = "Puppeteer: Give Recall Order"
+	description = "Give your puppets order to recall"
+	keybind_signal = COMSIG_XENOABILITY_RECALLORDER
 
 /datum/keybinding/xeno/bestow_blessing
 	name = "Bestow Blessings"

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/abilities_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/abilities_puppeteer.dm
@@ -490,7 +490,7 @@
 	name = "Give Order to Attack"
 	desc = "Give your puppets order to attack"
 	keybinding_signals = list(
-		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ATTACKORDER
+		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ATTACKORDER,
 	)
 
 /datum/action/ability/xeno_action/puppeteer_attack_order/action_activate(mob/living/victim)
@@ -511,7 +511,7 @@
 	name = "Give Order to Recall"
 	desc = "Give your puppets order to recall"
 	keybinding_signals = list(
-		KEYBINDING_NORMAL = COMSIG_XENOABILITY_RECALLORDER
+		KEYBINDING_NORMAL = COMSIG_XENOABILITY_RECALLORDER,
 	)
 
 /datum/action/ability/xeno_action/puppeteer_recall_order/action_activate(mob/living/victim)

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/abilities_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/abilities_puppeteer.dm
@@ -457,18 +457,18 @@
 	add_cooldown()
 
 // ***************************************
-// *********** Orders
+// *********** Radial Orders
 // ***************************************
 
-/datum/action/ability/xeno_action/puppeteer_orders
+/datum/action/ability/xeno_action/puppeteer_orders_radial
 	name = "Give Orders to Puppets"
 	action_icon_state = "orders"
 	desc = "Give orders to your puppets, altering their behaviour."
 	keybinding_signals = list(
-		KEYBINDING_NORMAL = COMSIG_XENOABILITY_SENDORDERS,
+		KEYBINDING_NORMAL = COMSIG_XENOABILITY_SENDORDERS_RADIAL,
 	)
 
-/datum/action/ability/xeno_action/puppeteer_orders/action_activate(mob/living/victim)
+/datum/action/ability/xeno_action/puppeteer_orders_radial/action_activate(mob/living/victim)
 	var/choice = show_radial_menu(owner, owner, GLOB.puppeteer_order_images_list, radius = 35)
 	if(!choice)
 		return
@@ -481,3 +481,45 @@
 				owner.visible_message(span_warning("[owner] quickly manipulates the psychic strings of the puppets, drawing them near!"))
 	else
 		owner.balloon_alert(owner, "fail")
+
+// ***************************************
+// *********** Attack Order
+// ***************************************
+
+/datum/action/ability/xeno_action/puppeteer_attack_order
+	name = "Give Order to Attack"
+	desc = "Give your puppets order to attack"
+	keybinding_signals = list(
+		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ATTACKORDER
+	)
+
+/datum/action/ability/xeno_action/puppeteer_attack_order/action_activate(mob/living/victim)
+	var/puppet_attack = PUPPET_ATTACK
+	if(SEND_SIGNAL(owner, COMSIG_PUPPET_CHANGE_ALL_ORDER, puppet_attack))
+		owner.balloon_alert(owner, "success: attack")
+	else
+		owner.balloon_alert(owner, "fail")
+
+/datum/action/ability/xeno_action/puppeteer_attack_order/should_show()
+	return FALSE
+
+// ***************************************
+// *********** Recall Order
+// ***************************************
+
+/datum/action/ability/xeno_action/puppeteer_recall_order
+	name = "Give Order to Recall"
+	desc = "Give your puppets order to recall"
+	keybinding_signals = list(
+		KEYBINDING_NORMAL = COMSIG_XENOABILITY_RECALLORDER
+	)
+
+/datum/action/ability/xeno_action/puppeteer_recall_order/action_activate(mob/living/victim)
+	var/puppet_recall = PUPPET_RECALL
+	if(SEND_SIGNAL(owner, COMSIG_PUPPET_CHANGE_ALL_ORDER, puppet_recall))
+		owner.balloon_alert(owner, "success: recall")
+
+/datum/action/ability/xeno_action/puppeteer_recall_order/should_show()
+	return FALSE
+
+

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
@@ -40,7 +40,9 @@
 		/datum/action/ability/activable/xeno/refurbish_husk,
 		/datum/action/ability/activable/xeno/puppet,
 		/datum/action/ability/activable/xeno/organic_bomb,
-		/datum/action/ability/xeno_action/puppeteer_orders,
+		/datum/action/ability/xeno_action/puppeteer_attack_order,
+		/datum/action/ability/xeno_action/puppeteer_recall_order,
+		/datum/action/ability/xeno_action/puppeteer_orders_radial,
 		/datum/action/ability/activable/xeno/articulate,
 		/datum/action/ability/activable/xeno/puppet_blessings,
 	)
@@ -70,7 +72,9 @@
 		/datum/action/ability/activable/xeno/puppet,
 		/datum/action/ability/activable/xeno/organic_bomb,
 		/datum/action/ability/activable/xeno/tendril_patch,
-		/datum/action/ability/xeno_action/puppeteer_orders,
+		/datum/action/ability/xeno_action/puppeteer_attack_order,
+		/datum/action/ability/xeno_action/puppeteer_recall_order,
+		/datum/action/ability/xeno_action/puppeteer_orders_radial,
 		/datum/action/ability/activable/xeno/articulate,
 		/datum/action/ability/activable/xeno/puppet_blessings,
 	)


### PR DESCRIPTION
Добавляет отдельные приказы на атаку и возврат, на панели их нет, но можно забиндить в кейбиндах.
Зачем? Это удобно.