### PR TITLE
Xeno Wall Cool PR МОДУЛЬНЫЙ

### DIFF
--- a/modular_RUtgmc/code/game/objects/structures/xeno.dm
+++ b/modular_RUtgmc/code/game/objects/structures/xeno.dm
@@ -9,7 +9,7 @@
 	var/turf/cur_loc = X.loc
 	if(!istype(cur_loc))
 		return FALSE
-	if(X.a_intent != INTENT_HARM)
+	if(X.a_intent != INTENT_DISARM)
 		try_toggle_state(X)
 		return TRUE
 	if(CHECK_BITFIELD(SSticker.mode?.flags_round_type, MODE_ALLOW_XENO_QUICKBUILD) && SSresinshaping.should_refund(src, X))
@@ -71,7 +71,10 @@
 	if(X.status_flags & INCORPOREAL)
 		return FALSE
 
-	if(X.a_intent == INTENT_HARM)
+	if(X.a_intent != INTENT_DISARM)
+		return FALSE
+
+	if(X.a_intent == INTENT_DISARM)
 		if(CHECK_BITFIELD(SSticker.mode?.flags_round_type, MODE_ALLOW_XENO_QUICKBUILD) && SSresinshaping.should_refund(src, X) && refundable)
 			SSresinshaping.decrement_build_counter(X)
 		X.do_attack_animation(src, ATTACK_EFFECT_CLAW)

--- a/modular_RUtgmc/code/game/turfs/walls/resin.dm
+++ b/modular_RUtgmc/code/game/turfs/walls/resin.dm
@@ -8,6 +8,8 @@
 /turf/closed/wall/resin/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL)
 		return
+	if(X.a_intent != INTENT_DISARM)
+		return
 	if(CHECK_BITFIELD(SSticker.mode?.flags_round_type, MODE_ALLOW_XENO_QUICKBUILD) && SSresinshaping.should_refund(src, X))
 		SSresinshaping.decrement_build_counter(X)
 		take_damage(max_integrity)


### PR DESCRIPTION
Вам надоело что вы занимаетесь быстрой постройкой один в улье, и вас никто не уважает? Регресайте в ранера.
Для тех кто остался
Теперь вы не будете ломать свою стену, когда её построили вплотную себе, никаких заёбов.
Почему?

Что бы поломать стену, теперь надо использовать синий интент

Почему не красный? 

Что бы когда вы дрались, вы не начала жёстко ломать стену одну секунду, пока мары рядом.

UPD
Друзья попросили что бы двери и резина ломались тоже на синим интенте а не на красном, я совсем забыл что двери существуют в билде.
Теперь двери и липкая резина тоже ломаются на синий интент