### PR TITLE
Ревёрт нерфа рапиры. Модульный!

### DIFF
--- a/modular_RUtgmc/code/game/objects/items/weapons/harvester.dm
+++ b/modular_RUtgmc/code/game/objects/items/weapons/harvester.dm
@@ -19,7 +19,7 @@
 	)
 	icon_state = "rapier"
 	item_state = "rapier"
-	force = 45
+	force = 60
 	attack_speed = 5
 
 /obj/item/weapon/claymore/mercsword/officersword/valirapier/Initialize(mapload)


### PR DESCRIPTION
То что в названии, урон рапиры был возвращён с 45 до 60.

Зачем это делается?
Как показал опыт игры в тгмс, нерф рапиры был ошибочным решением, теперь она не является достойной альтернативой обычного снаряжения. (Копья)