### PR TITLE
Lowers flare fuel limits values.

### DIFF
--- a/modular_RUtgmc/code/game/objects/items/explosives/marines.dm
+++ b/modular_RUtgmc/code/game/objects/items/explosives/marines.dm
@@ -58,5 +58,7 @@
 	icon_state_mini = "grenade_purple"
 
 /obj/item/explosive/grenade/flare
+	lower_fuel_limit = 450 // 450 * 2 (ticks) / 60 (seconds) = 15 minutes
+	upper_fuel_limit = 750 // 750 * 2 (ticks) / 60 (seconds) = 25 minutes
 	G_hit_sound = null
 	G_throw_sound = null


### PR DESCRIPTION
Понижено с 800 и 1000 до 450 и 750.
То есть с 27 и 33 минут до 15 и 25 минут.
За время горения флаера, мары могут успеть отъехать от ксен, перегруппироваться, перебить ксен, вернутся на позицию где отъехали, покурить, попить, поесть, и флаеры всё еще будут гореть xd.