### PR TITLE
Allows to put phosphorus trailblazers in the grenade launchers.

### DIFF
--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -45,6 +45,7 @@ The Grenade Launchers
 		/obj/item/explosive/grenade/impact,
 		/obj/item/explosive/grenade/sticky,
 		/obj/item/explosive/grenade/sticky/trailblazer,
+		/obj/item/explosive/grenade/sticky/trailblazer/phosphorus, // RUTGMC ADDITION
 		/obj/item/explosive/grenade/flare,
 		/obj/item/explosive/grenade/flare/cas,
 		/obj/item/explosive/grenade/chem_grenade,


### PR DESCRIPTION
Я изначально не знал что трейлблейзеры можно пихать в гранатомёты, поэтому и не добавил.