### PR TITLE
Fixes runtimes from gibbing the mob with ai and player.

### DIFF
--- a/code/datums/components/ai.dm
+++ b/code/datums/components/ai.dm
@@ -42,13 +42,13 @@ The main purpose of this is to handle cleanup and setting up the initial ai beha
 	if(ai_behavior)
 		STOP_PROCESSING(SSprocessing, ai_behavior)
 		ai_behavior.cleanup_signals()
-		ai_behavior.current_node = null // RUTGMC ADDITION START
-		ai_behavior.escorted_atom = null
-		ai_behavior.mob_parent = null // RUTGMC ADDITION END
 		ai_behavior.atom_to_walk_to = null
 		if(register_for_logout)
 			RegisterSignal(parent, COMSIG_MOB_LOGOUT, PROC_REF(start_ai))
 			return
+		ai_behavior.current_node = null // RUTGMC ADDITION START
+		ai_behavior.escorted_atom = null
+		ai_behavior.mob_parent = null // RUTGMC ADDITION END
 		ai_behavior = null
 
 ///Start the ai behaviour


### PR DESCRIPTION
Я не учёл, что очистка рефов также используется и для других процессов, кроме смерти.