### PR TITLE
Ryetalyn's death

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -189,8 +189,8 @@
 		new /obj/item/clothing/mask/cigarette/kelo(src)
 	for(var/i in 1 to 5)
 		new /obj/item/clothing/mask/cigarette/tram(src)
-	for(var/i in 1 to 5)
-		new /obj/item/clothing/mask/cigarette/antitox(src)
+//	for(var/i in 1 to 5)
+//		new /obj/item/clothing/mask/cigarette/antitox(src)
 
 	new /obj/item/clothing/mask/cigarette/emergency(src)
 	new /obj/item/tool/lighter(src)

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -87,7 +87,7 @@
 /obj/item/storage/firstaid/toxin/fill_firstaid_kit()
 	new /obj/item/healthanalyzer(src)
 	new /obj/item/storage/pill_bottle/dylovene(src)
-	new /obj/item/storage/pill_bottle/packet/ryetalyn(src)
+//	new /obj/item/storage/pill_bottle/packet/ryetalyn(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/hypervene(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/hypervene(src)
 	new /obj/item/storage/syringe_case/tox(src)

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -39,12 +39,12 @@
 	name = "Meralyne"
 	results = list(/datum/reagent/medicine/meralyne = 3)
 	required_reagents = list(/datum/reagent/medicine/inaprovaline = 1, /datum/reagent/medicine/bicaridine = 1, /datum/reagent/iron = 1, /datum/reagent/medicine/lemoline = 1)
-
+/* RU TGMC EDIT
 /datum/chemical_reaction/ryetalyn
 	name = "Ryetalyn"
 	results = list(/datum/reagent/medicine/ryetalyn = 2)
 	required_reagents = list(/datum/reagent/medicine/arithrazine = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/lemoline = 1)
-
+RU TGMC EDIT */
 /datum/chemical_reaction/cryoxadone
 	name = "Cryoxadone"
 	results = list(/datum/reagent/medicine/cryoxadone = 3)
@@ -147,7 +147,7 @@
 /datum/chemical_reaction/peridaxon_plus
 	name = "Peridaxon Plus"
 	results = list(/datum/reagent/medicine/peridaxon_plus = 1)
-	required_reagents = list(/datum/reagent/medicine/ryetalyn = 5, /datum/reagent/toxin/phoron = 5)
+	required_reagents = list(/datum/reagent/medicine/hyronalin = 5, /datum/reagent/toxin/phoron = 5) //RU TGMC EDIT
 
 /datum/chemical_reaction/quickclot
 	name = "Quick-Clot"

--- a/modular_RUtgmc/code/modules/reagents/reactions/medical.dm
+++ b/modular_RUtgmc/code/modules/reagents/reactions/medical.dm
@@ -1,8 +1,3 @@
-/datum/chemical_reaction/ryetalyn
-	name = "Ryetalyn"
-	results = list(/datum/reagent/medicine/ryetalyn = 2)
-	required_reagents = list(/datum/reagent/medicine/arithrazine = 1, /datum/reagent/carbon = 1)
-
 /datum/chemical_reaction/synaptizine
 	name = "Synaptizine"
 	results = list(/datum/reagent/medicine/synaptizine = 3)


### PR DESCRIPTION
## About The Pull Request
Риеталин больше нельзя сварить.
Сигарет и таблетниц с рейтой больше нигде нет. Рейталин теперь доступен только дед скваду.
Пери плюс теперь варится из хироналина и форона.

## Why It's Good For The Game
С удалением нейротоксина пропадают все причины оставлять рейту доступной для маров. Смертельных реагентов(особенно плевков нейро) у ксеносов больше нет. Для пурджа остальной их химии придется использовать диловен или гипервен.