### PR TITLE
Коробки для патрон дробовика весят меньше

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -45,7 +45,7 @@
 	desc = "A general purpose pouch used to carry small items."
 	icon_state = "small_drop"
 	draw_mode = 1
-	bypass_w_limit = list(/obj/item/ammo_magazine/packet)
+	bypass_w_limit = list(/obj/item/ammo_magazine/packet, /obj/item/ammo_magazine/shotgun) // RU TGMC EDIT
 
 /obj/item/storage/pouch/general/medium
 	name = "medium general pouch"

--- a/code/modules/projectiles/magazines/shotguns.dm
+++ b/code/modules/projectiles/magazines/shotguns.dm
@@ -14,7 +14,7 @@ one type of shotgun ammo, but I think it helps in referencing it. ~N
 	default_ammo = /datum/ammo/bullet/shotgun/slug
 	caliber = CALIBER_12G //All shotgun rounds are 12g right now.
 	max_rounds = 25 // Real shotgun boxes are usually 5 or 25 rounds. This works with the new system, five handfuls.
-	w_class = WEIGHT_CLASS_BULKY // Can't throw it in your pocket, friend.
+	w_class = WEIGHT_CLASS_NORMAL // Can't throw it in your pocket, friend.
 	icon_state_mini = "slugs"
 
 /obj/item/ammo_magazine/shotgun/incendiary


### PR DESCRIPTION
## About The Pull Request
Коробки вмещаются в рюкзак и поучи и прочие слоты под медиум сайз предметы

## Why It's Good For The Game
Надо

