### PR TITLE
Add neuraline to cargo

### DIFF
--- a/modular_RUtgmc/code/modules/reqs/supplypacks.dm
+++ b/modular_RUtgmc/code/modules/reqs/supplypacks.dm
@@ -436,6 +436,24 @@ MEDICAL
 	contains = list(/obj/item/storage/pill_bottle/russian_red)
 	cost = 30
 
+/datum/supply_packs/medical/neuraline_kit
+	name ="large neuraline kit"
+	notes = "contains five neuraline injectors"
+	contains = list(
+		/obj/item/reagent_containers/hypospray/autoinjector/neuraline,
+		/obj/item/reagent_containers/hypospray/autoinjector/neuraline,
+		/obj/item/reagent_containers/hypospray/autoinjector/neuraline,
+		/obj/item/reagent_containers/hypospray/autoinjector/neuraline,
+		/obj/item/reagent_containers/hypospray/autoinjector/neuraline,
+		)
+	cost = 250
+
+/datum/supply_packs/medical/neuraline_kit_injector
+	name ="Neuraline autoinjector"
+	notes = "contains one neuraline injector"
+	contains = list(/obj/item/reagent_containers/hypospray/autoinjector/neuraline)
+	cost = 70
+
 /datum/supply_packs/medical/bkkt_kit
 	name = "BKKT kit"
 	notes = "contains pill bottles BKKT."


### PR DESCRIPTION
Добавляет шприцы с нейролином в карго 
один за дорого (70) и партию из пяти штук в нормальную цену (250)

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->



## Why It's Good For The Game

Даст некоторую минимальную возможность пользоваться реагентом без излишней ебли готовки личиночного супа на кухне или запредельной дороговизны в вендоре, qol.

