### PR TITLE
Deletes modular copy `/datum/controller/subsystem/minimaps/Initialize()`, cherry picks upstream version properly.

### DIFF
--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -41,11 +41,9 @@ SUBSYSTEM_DEF(minimaps)
 	var/list/hashed_minimaps = list()
 
 /datum/controller/subsystem/minimaps/Initialize()
+	initialized = TRUE
 	for(var/datum/space_level/z_level AS in SSmapping.z_list)
 		load_new_z(null, z_level)
-	//RegisterSignal(SSdcs, COMSIG_GLOB_NEW_Z, PROC_REF(load_new_z))
-
-	initialized = TRUE
 
 	return SS_INIT_SUCCESS
 

--- a/modular_RUtgmc/code/controllers/subsystem/minimaps.dm
+++ b/modular_RUtgmc/code/controllers/subsystem/minimaps.dm
@@ -1,9 +1,2 @@
-/datum/controller/subsystem/minimaps/Initialize()
-	initialized = TRUE
-	for(var/datum/space_level/z_level AS in SSmapping.z_list)
-		load_new_z(null, z_level)
-
-	return SS_INIT_SUCCESS
-
 /atom/movable/screen/minimap_locator
 	icon = 'modular_RUTGMC/icons/UI_icons/map_blips.dmi'


### PR DESCRIPTION
Подтянул оригинальный пр.
Удалил модульные идентичные изменения.