### PR TITLE
Restricts ravagers gaining plasma from the fire tiles they don't take damage from.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
@@ -27,6 +27,8 @@
 	. = ..()
 	if(stat)
 		return
+	if(pass_flags & PASS_FIRE) // RUTGMC ADDITION START
+		return FALSE // RUTGMC ADDITION END
 	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_RAVAGER_FLAMER_ACT))
 		return FALSE
 	gain_plasma(50)


### PR DESCRIPTION
В прыжке можно было получать ярость.