### PR TITLE
Prevents deevolve punishment from deleting xenos in different stances.

### DIFF
--- a/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -151,6 +151,10 @@
 		to_chat(devolver, span_xenonotice("Cannot deevolve, [target] is ventcrawling."))
 		return
 
+	if(target.agility || target.fortify || target.crest_defense || target.status_flags & INCORPOREAL) // RUTGMC ADDITION, deevolve deleteion prevention
+		to_chat(devolver, span_xenonotice("Cannot deevolve, while [target] is in this stance."))
+		return FALSE
+
 	if(!isturf(target.loc))
 		to_chat(devolver, span_xenonotice("Cannot deevolve [target] here."))
 		return

--- a/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -151,7 +151,7 @@
 		to_chat(devolver, span_xenonotice("Cannot deevolve, [target] is ventcrawling."))
 		return
 
-	if(target.agility || target.fortify || target.crest_defense || target.status_flags & INCORPOREAL) // RUTGMC ADDITION, deevolve deleteion prevention
+	if(target.agility || target.fortify || target.crest_defense || target.status_flags & INCORPOREAL) // RUTGMC ADDITION, deevolve deletion prevention
 		to_chat(devolver, span_xenonotice("Cannot deevolve, while [target] is in this stance."))
 		return FALSE
 


### PR DESCRIPTION
Деэволв больше не будет удалять в фортифае\крест дефенсе\беге, а просто говорить что нельзя деэволвнуть пока цель находится в этом состоянии.