### PR TITLE
map fix

### DIFF
--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -4160,11 +4160,6 @@
 	dir = 8
 	},
 /area/outpost/caves/south)
-"tn" = (
-/obj/structure/window/framed/colony,
-/obj/structure/window/framed/colony,
-/turf/open/floor/tile/dark,
-/area/outpost/medbay/chemistry)
 "to" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -19060,7 +19055,7 @@ fe
 OR
 bR
 TX
-tn
+tr
 gr
 tr
 tr

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -9491,6 +9491,9 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "Xc" = (


### PR DESCRIPTION
Убирает лишнее окно в химии на карте Research Outpost.
Чинит трубу на втором ЛЗ на карте Icy Caves.