### PR TITLE
Few tweaks to carrier and hugger egg `attack_ghost`

### DIFF
--- a/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/carrier/carrier.dm
+++ b/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/carrier/carrier.dm
@@ -11,11 +11,13 @@
 	. = ..()
 
 	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
-	if(!hive.can_spawn_as_hugger(user))
+	if(stat == DEAD)
 		return FALSE
 
 	if(huggers_reserved >= huggers)
-		balloon_alert(user, "No facehuggers available.")
+		return FALSE
+
+	if(!hive.can_spawn_as_hugger(user))
 		return FALSE
 
 	var/mob/living/carbon/xenomorph/facehugger/new_hugger = new(get_turf(src))

--- a/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/egg.dm
+++ b/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/egg.dm
@@ -30,16 +30,14 @@
 //Observers can become playable facehuggers by clicking on the egg
 /obj/alien/egg/hugger/attack_ghost(mob/dead/observer/user)
 	. = ..()
-
 	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
-	if(!hive.can_spawn_as_hugger(user))
-		return FALSE
 
 	if(maturity_stage != stage_ready_to_burst)
-		balloon_alert(user, "Not fully grown")
 		return FALSE
 	if(!hugger_type)
-		balloon_alert(user, "Empty")
+		return FALSE
+
+	if(!hive.can_spawn_as_hugger(user))
 		return FALSE
 
 	advance_maturity(stage_ready_to_burst + 1)

--- a/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -46,8 +46,8 @@
 	if(GLOB.key_to_time_of_death[user.key] + TIME_BEFORE_TAKING_BODY > world.time && !user.started_as_observer)
 		to_chat(user, span_warning("You died too recently to be able to take a new facehugger."))
 		return FALSE
-
-	if(tgui_alert(user, "Are you sure you want to be a Facehugger?", "Become a part of the Horde", list("Yes", "No")) != "Yes")
+	
+	if(tgui_alert(user, "Are you sure you want to be a Facehugger?", "Become part of the Horde!", list("Yes", "No")) != "Yes")
 		return FALSE
 
 	if(length(facehuggers) >= MAX_FACEHUGGERS)


### PR DESCRIPTION
Удалил ненужные баллун алёрты.
Добавил проверку на то жив ли керриер перед тем как предлагать хаггеру с него слезть.
Переместил запрос на становление хаггером, после необходимых проверок.
Немного подкорректировал текст.