### PR TITLE
Floodlights are now breakable for xenos.

### DIFF
--- a/modular_RUtgmc/code/game/objects/machinery/floodlight.dm
+++ b/modular_RUtgmc/code/game/objects/machinery/floodlight.dm
@@ -1,0 +1,3 @@
+/obj/machinery/floodlight
+	max_integrity = 250
+	resistance_flags = XENO_DAMAGEABLE

--- a/modular_RUtgmc/includes.dm
+++ b/modular_RUtgmc/includes.dm
@@ -111,6 +111,7 @@
 #include "code\game\objects\machinery\adv_med.dm"
 #include "code\game\objects\machinery\autodoc.dm"
 #include "code\game\objects\machinery\deployable.dm"
+#include "code\game\objects\machinery\floodlight.dm"
 #include "code\game\objects\machinery\miner.dm"
 #include "code\game\objects\machinery\mortar.dm"
 #include "code\game\objects\machinery\OpTable.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ксеносы теперь могут ломать прожекторы, их хп уменьшено со стандартных для объектов 500, до 250, что на 50 выше переносимых прожекторов, и ломается в среднем за 12-13 ударов руньки.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Меньше мороки с ломанием прожекторов.
Прожекторы более не будут ультимативной баррикадой, которую можно только расплавить.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
