### PR TITLE
Properly restricts synthetics from attacking xenomorphs.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -182,10 +182,6 @@
 	if(M.status_flags & INCORPOREAL || user.status_flags & INCORPOREAL)
 		return FALSE
 
-	if(issynth(user) && isxeno(M)) // RUTGMC ADDITION START
-		to_chat(user, span_warning("Your program prohibits you from doing this!"))
-		return FALSE // RUTGMC ADDITION END
-
 	if(M.can_be_operated_on() && do_surgery(M, user, src)) //Checks if mob is lying down on table for surgery
 		return TRUE
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -182,6 +182,10 @@
 	if(M.status_flags & INCORPOREAL || user.status_flags & INCORPOREAL)
 		return FALSE
 
+	if(issynth(user) && isxeno(M)) // RUTGMC ADDITION START
+		to_chat(user, span_warning("Your program prohibits you from doing this!"))
+		return FALSE // RUTGMC ADDITION END
+
 	if(M.can_be_operated_on() && do_surgery(M, user, src)) //Checks if mob is lying down on table for surgery
 		return TRUE
 

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -327,6 +327,9 @@
 	SIGNAL_HANDLER
 	if(living_user.get_active_held_item() != src) // If the object in our active hand is not a throwing knife, abort
 		return
+	if(issynth(living_user)) // RUTGMC ADDITION START
+		to_chat(living_user, span_warning("Your program prohibits you from doing this!"))
+		return // RUTGMC ADDITION END
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"] || modifiers["ctrl"])
 		return

--- a/modular_RUtgmc/code/_onclick/item_attack.dm
+++ b/modular_RUtgmc/code/_onclick/item_attack.dm
@@ -1,0 +1,6 @@
+//Called before any other attack proc.
+/obj/item/weapon/preattack(atom/target, mob/user, params)
+	if(issynth(user) && isxeno(target))
+		to_chat(user, span_warning("Your program prohibits you from doing this!"))
+		return TRUE
+	return FALSE

--- a/modular_RUtgmc/code/game/objects/items/tools/mining_tools.dm
+++ b/modular_RUtgmc/code/game/objects/items/tools/mining_tools.dm
@@ -36,3 +36,10 @@
 	if(mention_charge && amount > 0)
 		balloon_alert(user, "Charge Remaining: [cell.charge]/[cell.maxcharge]")
 	update_plasmacutter()
+
+//Called before any other attack proc.
+/obj/item/tool/pickaxe/plasmacutter/preattack(atom/target, mob/user, params)
+	if(issynth(user) && isxeno(target)) // in theory we could add a flag that does this instead of copying proc for every item, but its just 2 currently
+		to_chat(user, span_warning("Your program prohibits you from doing this!"))
+		return TRUE
+	return FALSE

--- a/modular_RUtgmc/code/modules/mob/living/carbon/human/human.dm
+++ b/modular_RUtgmc/code/modules/mob/living/carbon/human/human.dm
@@ -60,7 +60,7 @@
 	if(!I || HAS_TRAIT(I, TRAIT_NODROP))
 		return
 
-	if(issynth(usr) && I.throwforce >= 15)
+	if(issynth(usr) && I.throwforce > 15)
 		to_chat(usr, span_warning("Your program prohibits you from doing this!"))
 		return
 

--- a/modular_RUtgmc/includes.dm
+++ b/modular_RUtgmc/includes.dm
@@ -4,6 +4,7 @@
 #include "code\_globalvars\lists\mapping.dm"
 #include "code\_globalvars\lists\mobs.dm"
 #include "code\_globalvars\lists\objects.dm"
+#include "code\_onclick\item_attack.dm"
 #include "code\_onclick\xeno.dm"
 #include "code\_onclick\hud\hud.dm"
 #include "code\_onclick\hud\screen_objects\menu_text_objects.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Копия https://github.com/Cosmic-Overlord/RU-TerraGov-Marine-Corps/pull/464, так как Лорианс забил хуй на пр, но с надеюсь лучшим кодом.

Метательные ножи и оружие с метательной силой больше 15 более нельзя бросать.
Оружие более нельзя использовать на ксеноморфах, включая паверфист и плазмакаттер. Можно заменить `isxeno` на `isliving`, или и вовсе убрать, но тогда нельзя будет ломать ту же траву.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
> Это позволит убрать правило о боесинтах и закрепит его на уровне кода.
> Желание ГА.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

